### PR TITLE
Add JPEG Compression and Refactor Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,43 @@ First install via dub: `dub add jpeg-turbod`
 
 Then use in your program like so:
 ```d
-import std.file;
-import std.stdio;
+import std.file : read, write;
+import std.stdio : writefln, writeln;
 
 import jpeg_turbod;
 
 void main()
 {
-    const auto jpegFile = "image.jpg";
-    auto jpeg = cast(ubyte[]) jpegFile.read;
+    const auto jpegFile = "image-in.jpg";
+    auto jpegInput = cast(ubyte[]) jpegFile.read;
 
     auto dc = new Decompressor();
     ubyte[] pixels;
     int width, height;
-    dc.decompress(jpeg, pixels, width, height);
+    bool decompressed = dc.decompress(jpegInput, pixels, width, height);
 
-    writefln("JPEG dimensions: %s x %s", width, height);
-    writefln("First pixel: [%s, %s, %s]", pixels[0], pixels[1], pixels[2]);
+    if (decompressed)
+    {
+      writefln("JPEG dimensions: %s x %s", width, height);
+      writefln("First pixel: [%s, %s, %s]", pixels[0], pixels[1], pixels[2]);   
+    }
+    else
+    {
+      dc.errorInfo.writeln;
+      return;
+    }
+
+    auto c = new Compressor();
+    ubyte[] jpegOutput;
+    bool compressed = c.compress(pixels, jpegOutput, width, height, 90);
+    if (compressed)
+    {
+      "image-out.jpg".write(jpegOutput);
+    }
+    else
+    {
+      c.errorInfo.writeln;
+    }
 }
 
 ```
@@ -46,5 +66,6 @@ During compilation dub will try to find libjpeg-turbo at the following locations
 ## Todo
  - Linux compatibility
  - Documentation
- - Access to error information
+ - ~~Compression to JPEG~~
+ - ~~Access to error information~~
  - Output of grayscale/B&W images

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ void main()
 
     if (decompressed)
     {
-      writefln("JPEG dimensions: %s x %s", width, height);
-      writefln("First pixel: [%s, %s, %s]", pixels[0], pixels[1], pixels[2]);   
+        writefln("JPEG dimensions: %s x %s", width, height);
+        writefln("First pixel: [%s, %s, %s]", pixels[0], pixels[1], pixels[2]);
     }
     else
     {
-      dc.errorInfo.writeln;
-      return;
+        dc.errorInfo.writeln;
+        return;
     }
 
     auto c = new Compressor();
@@ -45,11 +45,11 @@ void main()
     bool compressed = c.compress(pixels, jpegOutput, width, height, 90);
     if (compressed)
     {
-      "image-out.jpg".write(jpegOutput);
+        "image-out.jpg".write(jpegOutput);
     }
     else
     {
-      c.errorInfo.writeln;
+        c.errorInfo.writeln;
     }
 }
 

--- a/source/jpeg_turbod/compress.d
+++ b/source/jpeg_turbod/compress.d
@@ -4,54 +4,53 @@ import jpeg_turbod.libjpeg_turbo;
 
 class Compressor
 {
-	private
+    private
     {
         tjhandle compressor;
         enum int rgbPixelSize = 3;
     }
 
-	this()
-	{
-		compressor = tjInitCompress();
-	}
-
-	~this()
-	{
-		tjDestroy(compressor);
-	}
-
-	final char[] errorInfo()
-	{
-		import std.string : fromStringz;
-
-     	return fromStringz(tjGetErrorStr2(compressor));
-	}
-
-	final bool compress(in ubyte[] pixels, ref ubyte[] jpeg, int width, int height, int quality = 80)
-	in
-	{
-		assert(quality >= 0 && quality <= 100, "JPEG quality must be in the range [0, 100].");
-	}
-	do
+    this()
     {
-     	int pitch = 0; // jpeg_turbo will comput the pitch using width and the pixel format.
-     	ulong jpegSize = pixels.length;
-     	ubyte* allocBuffer;
+        compressor = tjInitCompress();
+    }
 
-     	allocBuffer = tjAlloc(cast(int)jpegSize);
+    ~this()
+    {
+        tjDestroy(compressor);
+    }
 
-     	int result = tjCompress2(compressor, pixels.ptr, width, pitch, height,
-     		TJPF.TJPF_RGB, &(allocBuffer), &jpegSize, TJSAMP.TJSAMP_444, quality, 
-     		TJFLAG_ACCURATEDCT);
+    final char[] errorInfo()
+    {
+        import std.string : fromStringz;
 
-     	if (result == 0)
-     	{
-     		jpeg = allocBuffer[0..jpegSize];
-     		return true;
-     	}
-     	else
-     	{
-     		return false;
-     	}
+        return fromStringz(tjGetErrorStr2(compressor));
+    }
+
+    final bool compress(in ubyte[] pixels, ref ubyte[] jpeg, int width, int height, int quality = 80)
+    in
+    {
+        assert(quality >= 0 && quality <= 100, "JPEG quality must be in the range [0, 100].");
+    }
+    do
+    {
+        int pitch = 0; // jpeg_turbo will comput the pitch using width and the pixel format.
+        ulong jpegSize = pixels.length;
+        ubyte* allocBuffer;
+
+        allocBuffer = tjAlloc(cast(int) jpegSize);
+
+        int result = tjCompress2(compressor, pixels.ptr, width, pitch, height, TJPF.TJPF_RGB,
+                &(allocBuffer), &jpegSize, TJSAMP.TJSAMP_444, quality, TJFLAG_ACCURATEDCT);
+
+        if (result == 0)
+        {
+            jpeg = allocBuffer[0 .. jpegSize];
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
 }

--- a/source/jpeg_turbod/compress.d
+++ b/source/jpeg_turbod/compress.d
@@ -1,0 +1,57 @@
+module jpeg_turbod.compress;
+
+import jpeg_turbod.libjpeg_turbo;
+
+class Compressor
+{
+	private
+    {
+        tjhandle compressor;
+        enum int rgbPixelSize = 3;
+    }
+
+	this()
+	{
+		compressor = tjInitCompress();
+	}
+
+	~this()
+	{
+		tjDestroy(compressor);
+	}
+
+	final char[] errorInfo()
+	{
+		import std.string : fromStringz;
+
+     	return fromStringz(tjGetErrorStr2(compressor));
+	}
+
+	final bool compress(in ubyte[] pixels, ref ubyte[] jpeg, int width, int height, int quality = 80)
+	in
+	{
+		assert(quality >= 0 && quality <= 100, "JPEG quality must be in the range [0, 100].");
+	}
+	do
+    {
+     	int pitch = 0; // jpeg_turbo will comput the pitch using width and the pixel format.
+     	ulong jpegSize = pixels.length;
+     	ubyte* allocBuffer;
+
+     	allocBuffer = tjAlloc(cast(int)jpegSize);
+
+     	int result = tjCompress2(compressor, pixels.ptr, width, pitch, height,
+     		TJPF.TJPF_RGB, &(allocBuffer), &jpegSize, TJSAMP.TJSAMP_444, quality, 
+     		TJFLAG_ACCURATEDCT);
+
+     	if (result == 0)
+     	{
+     		jpeg = allocBuffer[0..jpegSize];
+     		return true;
+     	}
+     	else
+     	{
+     		return false;
+     	}
+    }
+}

--- a/source/jpeg_turbod/libjpeg_turbo/turbojpeg.d
+++ b/source/jpeg_turbod/libjpeg_turbo/turbojpeg.d
@@ -25,3 +25,18 @@ enum TJPF
 enum int TJFLAG_FASTDCT = 2048;
 
 enum int TJFLAG_ACCURATEDCT = 4096;
+
+tjhandle tjInitCompress();
+
+int tjCompress2(tjhandle handle, const ubyte* srcBuf, int width, int pitch, int height, 
+	int pixelFormat, ubyte** jpegBuf, ulong* jpegSize, int jpegSubsamp, int jpegQual, 
+	int flags);
+
+ulong tjBufSize(int width, int height, int jpegSubsamp);
+
+ubyte* tjAlloc(int bytes);
+
+enum TJSAMP
+{
+	TJSAMP_444 = 0
+}

--- a/source/jpeg_turbod/libjpeg_turbo/turbojpeg.d
+++ b/source/jpeg_turbod/libjpeg_turbo/turbojpeg.d
@@ -28,9 +28,9 @@ enum int TJFLAG_ACCURATEDCT = 4096;
 
 tjhandle tjInitCompress();
 
-int tjCompress2(tjhandle handle, const ubyte* srcBuf, int width, int pitch, int height, 
-	int pixelFormat, ubyte** jpegBuf, ulong* jpegSize, int jpegSubsamp, int jpegQual, 
-	int flags);
+int tjCompress2(tjhandle handle, const ubyte* srcBuf, int width, int pitch,
+        int height, int pixelFormat, ubyte** jpegBuf, ulong* jpegSize,
+        int jpegSubsamp, int jpegQual, int flags);
 
 ulong tjBufSize(int width, int height, int jpegSubsamp);
 
@@ -38,5 +38,5 @@ ubyte* tjAlloc(int bytes);
 
 enum TJSAMP
 {
-	TJSAMP_444 = 0
+    TJSAMP_444 = 0
 }

--- a/source/jpeg_turbod/package.d
+++ b/source/jpeg_turbod/package.d
@@ -1,3 +1,4 @@
 module jpeg_turbod;
 
+public import jpeg_turbod.compress;
 public import jpeg_turbod.decompress;


### PR DESCRIPTION
    JPEGs can now be compressed via a Compressor.

    Compression/decompression methods now return a boolean indicating
    success. If they are not successful and error description can be
    accessed via errorInfo.